### PR TITLE
Return implicit SOA records for subdomains.

### DIFF
--- a/server/search.py
+++ b/server/search.py
@@ -40,8 +40,7 @@ def search(domain, q_type):
                 auth_list.extend(p_auth_list)
             else:
                 auth_list.extend(p_rr_list)
-    logger.info("Response: " + str(rr_list))
-    print(auth_list)
+    logger.info("Response: " + domain + " RR: " + str(rr_list) + " Auth: " + str(auth_list) + " Add: " + str(addi_list))
     return rr_list, auth_list, addi_list
 
 def _identify_record(record, q_type):


### PR DESCRIPTION
### SOA records
- SOA records of subdomains should be returned implicitly under the authority section of a DNS response, if the parent domain is registered with UH DNS.
- This removes the need to have SOA records for each subdomain. Instead only a single record is needed at the domain apex.

Fixes #1 